### PR TITLE
Comparison model `omitempty` issues

### DIFF
--- a/rally2-matching-system/go-example/main.go
+++ b/rally2-matching-system/go-example/main.go
@@ -123,11 +123,11 @@ func compareList(w http.ResponseWriter, r *http.Request) {
 			template2 := C.CString(string(decoded2))
 			defer C.free(unsafe.Pointer(template2))
 
-			s := C.cpp_compare_template(template1, template2)
+			s := float32(C.cpp_compare_template(template1, template2))
 
 			cList = append(cList, models.Comparison{
-				Score:           float32(s),
-				NormalizedScore: float32(s),
+				Score:           &s,
+				NormalizedScore: &s,
 			})
 		}
 

--- a/rally2-matching-system/go-example/models/comparison.go
+++ b/rally2-matching-system/go-example/models/comparison.go
@@ -6,8 +6,8 @@ package models
 type Comparison struct {
 
 	// Similarity score between 0 and 1, with 1 being the highest score the algorithm can produce
-	NormalizedScore float32 `json:"NormalizedScore,omitempty"`
+	NormalizedScore *float32 `json:"NormalizedScore,omitempty"`
 
 	// An un-normalized similarity score, as produced by the algorithm
-	Score float32 `json:"Score,omitempty"`
+	Score *float32 `json:"Score,omitempty"`
 }


### PR DESCRIPTION
 Similarity scores of `0` are currently being omitted. This PR makes the "empty" value for these similarity scores a `nil` pointer rather than `0`.