### PR TITLE
Update Description for PAD API Spec

### DIFF
--- a/apis/pad-systems/active-pad-system/api/active-pad-system.yaml
+++ b/apis/pad-systems/active-pad-system/api/active-pad-system.yaml
@@ -13,7 +13,7 @@ info:
   contact:
     name: The MdTF
     url: https://mdtf.org
-    email: rivtd@mdtf.org
+    email: rivr@mdtf.org
   license:
     name: IDSL API License
     url: https://raw.githubusercontent.com/TheMdTF/mdtf-public/master/LICENSE.md
@@ -36,7 +36,7 @@ paths:
     post:
       summary: Create a biometric data capture with associated PAD information.
       description: |
-        Active PAD systems may submit data through this endpoint.  This request cannot exceed 100 Megabytes in size.
+        Active PAD systems may submit data through this endpoint. This request cannot exceed 100 Megabytes in size.
       tags:
         - Data Submission
       requestBody:
@@ -101,8 +101,8 @@ components:
           example: 0.8
         PADProperties:
           description: Key value pairs describing presentation attack properties and their relationship to the presentation attack outcome/score. 
-            There are no strictly defined  properties. The inclusion of descriptive properties is encouraged to provide
-            more context. (optional)
+            There are no strictly defined properties. The inclusion of descriptive properties is encouraged to provide
+            more context. Do not include image bytes in the properties. (optional)
           type: array
           items:
             $ref: '#/components/schemas/PADProperty'

--- a/apis/pad-systems/active-pad-system/api/readme.md
+++ b/apis/pad-systems/active-pad-system/api/readme.md
@@ -16,7 +16,7 @@ Base URLs:
 
         * 8080
 
-Email: <a href="mailto:rivtd@mdtf.org">The MdTF</a> Web: <a href="https://mdtf.org">The MdTF</a> 
+Email: <a href="mailto:rivr@mdtf.org">The MdTF</a> Web: <a href="https://mdtf.org">The MdTF</a> 
 License: <a href="https://raw.githubusercontent.com/TheMdTF/mdtf-public/master/LICENSE.md">IDSL API License</a>
 
 <h1 id="the-maryland-test-facility-active-presentation-attack-detection-system-interface-data-submission">Data Submission</h1>
@@ -116,7 +116,7 @@ func main() {
 
 `POST /v1/capture-data-with-pad`
 
-Active PAD systems may submit data through this endpoint.  This request cannot exceed 100 Megabytes in size.
+Active PAD systems may submit data through this endpoint. This request cannot exceed 100 Megabytes in size.
 
 > Body parameter
 
@@ -306,7 +306,7 @@ Data transfer object for presentation attack information.
 |---|---|---|---|---|
 |PADOutcome|boolean|true|none|Whether a presentation attack was determined to be detected (True) or not detected (False).|
 |PADScore|number(double)|true|none|A score corresponding to the level of confidence that a presentation attack was detected ranging between 0 and 1.|
-|PADProperties|[[PADProperty](#schemapadproperty)]|false|none|Key value pairs describing presentation attack properties and their relationship to the presentation attack outcome/score. There are no strictly defined  properties. The inclusion of descriptive properties is encouraged to provide more context. (optional)|
+|PADProperties|[[PADProperty](#schemapadproperty)]|false|none|Key value pairs describing presentation attack properties and their relationship to the presentation attack outcome/score. There are no strictly defined properties. The inclusion of descriptive properties is encouraged to provide more context. Do not include image bytes in the properties. (optional)|
 
 <h2 id="tocS_PADProperty">PADProperty</h2>
 <!-- backwards compatibility -->

--- a/apis/pad-systems/passive-pad-system/api/passive-pad-system.yaml
+++ b/apis/pad-systems/passive-pad-system/api/passive-pad-system.yaml
@@ -6,7 +6,7 @@ info:
   contact:
     name: The MdTF
     url: https://mdtf.org
-    email: rivtd@mdtf.org
+    email: rivr@mdtf.org
   license:
     name: IDSL API License
     url: https://raw.githubusercontent.com/TheMdTF/mdtf-public/master/LICENSE.md
@@ -85,7 +85,7 @@ components:
           format: double
           example: 0.8
         PADProperties:
-          description: Key value pairs describing presentation attack properties and their relationship to the presentation attack outcome/score.  There are no strictly defined properties.  The inclusion of descriptive properties is encouraged to provide more context.  (optional)
+          description: Key value pairs describing presentation attack properties and their relationship to the presentation attack outcome/score.  There are no strictly defined properties.  The inclusion of descriptive properties is encouraged to provide more context. Do not include image bytes in the properties. (optional)
           type: array
           items:
             $ref: '#/components/schemas/PADProperty'

--- a/apis/pad-systems/passive-pad-system/api/readme.md
+++ b/apis/pad-systems/passive-pad-system/api/readme.md
@@ -16,7 +16,7 @@ Base URLs:
 
         * 8080
 
-Email: <a href="mailto:rivtd@mdtf.org">The MdTF</a> Web: <a href="https://mdtf.org">The MdTF</a> 
+Email: <a href="mailto:rivr@mdtf.org">The MdTF</a> Web: <a href="https://mdtf.org">The MdTF</a> 
 License: <a href="https://raw.githubusercontent.com/TheMdTF/mdtf-public/master/LICENSE.md">IDSL API License</a>
 
 <h1 id="the-maryland-test-facility-passive-presentation-attack-detection-system-interface-data-analysis">Data Analysis</h1>
@@ -337,7 +337,7 @@ Data transfer object for presentation attack information.
 |---|---|---|---|---|
 |PADOutcome|boolean|true|none|Whether a presentation attack was determined to be detected (True) or not detected (False).  The outcome should be calibrated to produce a BPCER of 0.01.|
 |PADScore|number(double)|true|none|A score corresponding to the level of confidence that a presentation attack was detected ranging between 0 and 1.|
-|PADProperties|[[PADProperty](#schemapadproperty)]|false|none|Key value pairs describing presentation attack properties and their relationship to the presentation attack outcome/score.  There are no strictly defined properties.  The inclusion of descriptive properties is encouraged to provide more context.  (optional)|
+|PADProperties|[[PADProperty](#schemapadproperty)]|false|none|Key value pairs describing presentation attack properties and their relationship to the presentation attack outcome/score.  There are no strictly defined properties.  The inclusion of descriptive properties is encouraged to provide more context. Do not include image bytes in the properties. (optional)|
 
 <h2 id="tocS_PADProperty">PADProperty</h2>
 <!-- backwards compatibility -->


### PR DESCRIPTION
Update the descriptions to reflect the differences between the RIVTD event and the RIVR event.